### PR TITLE
feat(page): Add path rewrite whitelist

### DIFF
--- a/packages/page-html/src/pagePlugin.ts
+++ b/packages/page-html/src/pagePlugin.ts
@@ -79,7 +79,7 @@ export function createPagePlugin(pluginOptions: PluginOptions = {}): Plugin {
 					verbose: !!process.env.DEBUG && process.env.DEBUG !== 'false',
 					disableDotRule: undefined,
 					htmlAcceptHeaders: ['text/html', 'application/xhtml+xml'],
-					rewrites: createRewrites(pages, viteConfig),
+					rewrites: createRewrites(pages, viteConfig, pluginOptions),
 				}) as Connect.NextHandleFunction
 			)
 		},

--- a/packages/page-html/src/types.ts
+++ b/packages/page-html/src/types.ts
@@ -48,6 +48,11 @@ export interface PluginOptions {
 	 * @description inject data and tags to html.
 	 */
 	inject?: InjectOptions
+
+	/**
+	 * @description Whitelist, where no redirection is performed when matched to these paths
+	 */
+	rewriteWhitelist?: RegExp
 }
 
 /** page configurations */

--- a/packages/page-html/src/utils/core.ts
+++ b/packages/page-html/src/utils/core.ts
@@ -125,7 +125,7 @@ function createRewrite(reg: string, page: PageItem, baseUrl: string, proxyKeys: 
 /**
  * 生成重写规则
  */
-export function createRewrites(pages: Pages, viteConfig: ResolvedConfig): Rewrite[] {
+export function createRewrites(pages: Pages, viteConfig: ResolvedConfig, options: PluginOptions = {}): Rewrite[] {
 	const rewrites: Rewrite[] = []
 	const indexReg = /(\S+)(\/index\/?)$/
 	const baseUrl = viteConfig.base ?? '/'
@@ -144,7 +144,18 @@ export function createRewrites(pages: Pages, viteConfig: ResolvedConfig): Rewrit
 			rewrites.push(createRewrite(`${_path}(/)?`, page, baseUrl, proxyKeys))
 		}
 	})
-	// 3. 支持 `/` 请求
+	// 3. 白名单，匹配到这些路径时不进行重定向
+	rewrites.push({
+    from: /^\/(__unocss|__devtools__)\/$/,
+    to: ({ parsedUrl }) => parsedUrl.pathname as string
+  })
+	if (options.rewriteWhitelist instanceof RegExp) {
+		rewrites.push({
+			from: options.rewriteWhitelist,
+			to: ({ parsedUrl }) => parsedUrl.pathname as string
+		})
+	}
+	// 4. 支持 `/` 请求
 	rewrites.push(createRewrite('', pages['index'] ?? {}, baseUrl, proxyKeys))
 
 	return rewrites


### PR DESCRIPTION
- 在 PluginOptions 接口中添加 rewriteWhitelist 属性，用于配置白名单
- 修改 createRewrites 函数，支持白名单路径的重写规则
- 默认添加 /__unocss 和 /__devtools__ 路径到白名单